### PR TITLE
harden: the artefact is proven where operators install it, and an inert scope has to be telling the truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,42 @@ jobs:
           BASE: ${{ github.base_ref }}
         run: node tools/dev/check-scopes.ts --base "origin/$BASE"
 
+  # why on demand and not on every pull request: this resolves dependencies from the network and installs globally,
+  # which is why it is a release step rather than a gate step ([/decisions/ad-102.md](/decisions/ad-102.md)). But the
+  # release is the *only* place it ran, so a change to the verification itself could not be proven on the two
+  # platforms it exists for until after the merge that would publish it. `workflow_dispatch` on a branch closes that
+  # ([/decisions/ad-103.md](/decisions/ad-103.md)).
+  artefact:
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    name: artefact · ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Install Bun (build toolchain)
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.14"
+
+      - run: npm ci
+
+      - name: Pack it, install it, drive it
+        run: node tools/dev/verify-package.mjs
+
   test:
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # why a job of its own and not a step of the gate: it reads a commit range, and the gate reads the working tree.
+  # There is no base to compare against on `main`, which is also the moment it would be too late — an inert scope
+  # that lied has already decided the version by then ([/decisions/ad-103.md](/decisions/ad-103.md)).
+  #
+  # why not on the matrix: the answer does not vary by platform, and asking it four times is three runners spent on
+  # a question already answered.
+  scopes:
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # why full history: the check walks every commit of the pull request, and the base branch has to exist
+          # locally for the range to resolve at all.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      - name: An inert scope must not change what the package ships
+        run: node tools/dev/check-scopes.ts --base "origin/${{ github.base_ref }}"
+
   test:
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,13 @@ jobs:
         with:
           node-version: "24"
 
+      # hazard: `${{ github.base_ref }}` expanded straight into a `run:` block is code injection — a branch name is
+      # attacker-controllable text, and zizmor reports it as high confidence. It travels as an environment variable
+      # for that reason, which is the same shape every other interpolation in these workflows already uses.
       - name: An inert scope must not change what the package ships
-        run: node tools/dev/check-scopes.ts --base "origin/${{ github.base_ref }}"
+        env:
+          BASE: ${{ github.base_ref }}
+        run: node tools/dev/check-scopes.ts --base "origin/$BASE"
 
   test:
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,14 @@ name: Release
 #
 # ORDER, and why it is this order:
 #
-#   gate → decide → [approval] → assert → bump + changelog + dist (local) → verify the artefact →
-#   npm publish (OIDC, no token) → push commit+tag → release
+#   gate → decide → verify the artefact on three platforms → [approval] → assert →
+#   bump + changelog + dist (local) → verify the bumped artefact → npm publish (OIDC, no token) →
+#   push commit+tag → release → drive the published version on three platforms
+#
+# why the artefact is verified BEFORE the approval: the approval is a person deciding to make something
+# irreversible, and it is only worth asking for once the thing being published has been installed and driven
+# where operators install it. Every defect that reached an operator was an install defect, and install is the most
+# platform-shaped code in the package ([/decisions/ad-103.md](/decisions/ad-103.md)).
 #
 # `decide` reads and writes nothing, so the approval is requested only when there is a version to publish. The
 # approval is the `publish` environment on the one job that writes — structural, not a condition: GitHub does not
@@ -96,6 +102,50 @@ jobs:
           echo "### Nothing to release" >> "$GITHUB_STEP_SUMMARY"
           echo "Staying on ${{ steps.plan.outputs.current }}. Only \`feat\`, \`fix\` and \`perf\` outside the inert scopes release." >> "$GITHUB_STEP_SUMMARY"
 
+  # invariant: the tarball is installed and driven on every platform the package claims, before a human is asked to
+  # approve anything. The gate runs on four legs and proves the working tree; this proves the artefact — and the
+  # artefact used to be proven on Linux alone, inside a container that exists nowhere else, while `~/.local/bin`
+  # against a `.cmd` shim and `PATH` against `PATHEXT` are precisely where install goes wrong
+  # ([/decisions/ad-103.md](/decisions/ad-103.md)).
+  #
+  # why `needs: [decide]` and not the gate: this reads nothing the gate writes, so waiting for a four-leg matrix
+  # would serialise two things that answer different questions. `release` needs both, so nothing is published
+  # behind either one being red.
+  verify:
+    needs: [decide]
+    if: needs.decide.outputs.released == 'true'
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    name: artefact · ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+          cache: npm
+
+      # why Bun here too: `prepack` runs the bundler, so packing needs it on every platform this runs on.
+      - name: Install Bun (build toolchain)
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.14"
+
+      - run: npm ci
+
+      # invariant: no `shell:` override. The script spawns one process per step rather than composing a POSIX
+      # script, which is what lets the same command run on all three.
+      - name: Pack it, install it, drive it
+        run: node tools/dev/verify-package.mjs
+
   # why: the approval lives HERE, on the job that writes, and there is no separate gate job. A previous shape put
   # `environment: publish` on an approval job carrying `if: github.actor != '…bot'` — so on the bot's own push that
   # job was skipped, and the release job's `always()` condition let the publish through with no required reviewer at
@@ -105,7 +155,7 @@ jobs:
   # invariant: this is the only job that writes anywhere — npm, the branch, the tag, the release. Everything before
   # it reads.
   release:
-    needs: [gate, decide]
+    needs: [gate, decide, verify]
     if: needs.decide.outputs.released == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -325,4 +375,39 @@ jobs:
           gh release create "$TAG" --repo "$REPO" \
             --title "v${VERSION}" \
             --notes "See [CHANGELOG.md](https://github.com/${REPO}/blob/${TAG}/CHANGELOG.md)."
+
+  # why after the irreversible step, knowing it cannot undo it: everything before this reads a tarball built here.
+  # What an operator installs is what the registry serves, and the two have differed. There is no rollback — versions
+  # are immutable and moving `latest` needs a token — so this cannot prevent anything. What it does is turn "a person
+  # finds it on their own machine, days later" into "the run goes red, minutes later", which is the difference
+  # between shipping the next patch today and hearing about it from a user ([/decisions/ad-103.md](/decisions/ad-103.md)).
+  #
+  # invariant: it installs the exact version just published, from the registry, on every platform the package claims.
+  smoke:
+    needs: [decide, release]
+    if: needs.decide.outputs.released == 'true'
+    permissions: {}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    name: published · ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+
+      # why a retry and not a bare run: the registry is eventually consistent across its CDN, so the version can be
+      # a few seconds behind the publish that created it. A failure here must mean the package is broken, not that
+      # it is new.
+      - name: Drive the published version
+        env:
+          SPEC: "@tech-leads-club/harness-toolkit@${{ needs.decide.outputs.version }}"
+        run: node tools/dev/verify-package.mjs --from "$SPEC" --retries 6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ Each entry is an architectural decision record: what changed, why, what was refu
 A **Needs your action** line is a change `tlc harness doctor` cannot detect for you; everything else
 doctor reports against your own configuration.
 
-## v0.4.3
+## Unreleased
 
 - **AD-102** — A green gate is not a working product, so four checks that look where it cannot
+- **AD-103** — The artefact is proven where operators install it, and an inert scope has to be telling the truth
 
 ## v0.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,11 @@ doctor reports against your own configuration.
 
 ## Unreleased
 
-- **AD-102** — A green gate is not a working product, so four checks that look where it cannot
 - **AD-103** — The artefact is proven where operators install it, and an inert scope has to be telling the truth
+
+## v0.4.3
+
+- **AD-102** — A green gate is not a working product, so four checks that look where it cannot
 
 ## v0.4.2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,22 +97,31 @@ CLAUDE_PROJECT_DIR="$PWD" TLC_PROJECT_DIR="$PWD" tlc harness test
 ### What the gate deliberately cannot see
 
 The suite runs against the working tree with a fake home, which is what keeps it from writing into yours — and it is
-also what it cannot speak about. Two checks live outside it for that reason
-([/decisions/ad-102.md](/decisions/ad-102.md)):
+also what it cannot speak about. Three checks live outside it for that reason
+([/decisions/ad-102.md](/decisions/ad-102.md), [/decisions/ad-103.md](/decisions/ad-103.md)):
 
 ```bash
-node tools/dev/verify-package.mjs
+node tools/dev/verify-package.mjs                                  # the artefact, on this platform
+node tools/dev/verify-package.mjs --from <name@version>            # the published artefact, from the registry
+node tools/dev/check-scopes.ts --base origin/main                  # an inert scope that changes what ships
 ```
 
-Packs the tarball, asserts its payload, installs it into a container the way `npx` would, and drives the installed
-command. It is a release step, not a gate step: it resolves dependencies from the network. Without docker it falls
-back to a throwaway npm prefix and says so, because a weaker check reported as the stronger one is worse than none.
+The first packs the tarball, asserts its payload against npm's own file list, installs it into a throwaway npm
+prefix with a scratch home the way `npx` would, and drives `version`, `install` and `doctor`. It is a release step,
+not a gate step: it resolves dependencies from the network. It spawns one process per step and composes no shell,
+which is what lets the same script run on Linux, macOS and Windows — in the release pipeline it runs on all three
+before anything is published.
 
 Three install defects reached operators through this gap — 0.3.0 installed nothing, 0.3.2 shipped bundles where
-every entry answered as the CLI, 0.4.0 left `tlc` off `PATH`. Every one was found by a person on their own machine.
+every entry answered as the CLI, 0.4.0 left `tlc` off `PATH`. Every one was found by a person on their own machine,
+and until this ran on three platforms the artefact was only ever installed on one.
 
-The Windows leg of CI is the other one. A POSIX path assumption in a test passes on every developer machine here and
-fails there, which is exactly what happened — and the check worked.
+`check-scopes` reads a commit range, so it runs on the pull request rather than here. `fix(gate)` and the other
+inert scopes never release; this is what checks that a commit wearing one is really plumbing, and not a fix an
+operator needs that will now wait for somebody else's release to carry it.
+
+The Windows leg of CI is the third. A POSIX path assumption in a test passes on every developer machine here and
+fails there, which is exactly what happened — twice — and the check worked both times.
 
 ## Releasing
 
@@ -122,7 +131,13 @@ workflow filename, environment name — so there is no stored secret to steal an
 generated from that same identity ([/decisions/ad-102.md](/decisions/ad-102.md)).
 
 **What makes it safe is the gate, not a gate-keeper:** eighteen steps on four platforms, then the packed tarball
-installed into a container and driven as a real command, and only then `npm publish`.
+installed and driven as a real command on Linux, macOS and Windows, then a human approval, and only then
+`npm publish`. After it, the version that reached the registry is installed from the registry on the same three
+platforms — which cannot prevent anything, and turns "an operator finds it days later" into "the run goes red in
+minutes" ([/decisions/ad-103.md](/decisions/ad-103.md)).
+
+The order matters and is argued in the workflow itself: the artefact is proven **before** the approval, because the
+approval is a person deciding to make something irreversible.
 
 Two settings outside this repository decide whether "tokenless" is true or merely available:
 

--- a/docs/decisions/ad-103.md
+++ b/docs/decisions/ad-103.md
@@ -1,0 +1,92 @@
+---
+type: Decision
+title: "AD-103 — The artefact is proven where operators install it, and an inert scope has to be telling the truth"
+description: "The packed tarball is installed and driven on Linux, macOS and Windows before the approval that makes publishing irreversible — the clean room stopped being a Linux-only container for that reason. The verification composes no shell: one process per step. After the publish, the published version is installed from the registry on the same three platforms, as detection rather than prevention, because a registry has no rollback. And a commit wearing a scope that never releases may not change code the package ships."
+tags: [decision, release, ci, supply-chain, portability]
+timestamp: "2026-08-21"
+---
+
+# AD-103 — The artefact is proven where operators install it, and an inert scope has to be telling the truth
+
+- **status**: active
+
+## Decision
+
+1. **The artefact is verified on every platform the package claims, before the approval.** A matrix job packs the
+   tarball, installs it into a throwaway prefix with a scratch home, and drives `version`, `install` and `doctor` on
+   `ubuntu-latest`, `macos-latest` and `windows-latest`. `release` cannot start without it.
+2. **The clean room is one room, everywhere, and not a container.** The container was the stronger room and existed
+   on Linux alone; a third platform buys more than the extra isolation did.
+3. **The verification composes no shell.** One process per step, its own exit status, and an `expect` field read
+   against captured output instead of a `grep` pipeline.
+4. **After the publish, the published version is driven from the registry** on the same three platforms. This is
+   detection, not prevention, and it is written down as such.
+5. **A commit with an inert scope may not change code the package ships.** `tools/dev/check-scopes.ts` fails the
+   pull request, with documentation exempt.
+
+## Why
+
+**The gate proves the working tree; operators install the package.** That gap already cost three releases — 0.3.0
+installed nothing, 0.3.2 shipped bundles where every entry answered as the CLI, 0.4.0 left `tlc` off `PATH`. The
+clean-room verification was added for exactly that ([/decisions/ad-102.md](/decisions/ad-102.md)) and then ran on
+one platform, in a container, because the container is only available there.
+
+**So the least-verified platform was the one most likely to break.** Install is the most platform-shaped code in
+this package: `~/.local/bin` against a `.cmd` shim, `PATH` against `PATHEXT`, a link against a copy. The Windows leg
+of CI has already caught two path defects a POSIX gate structurally cannot see — a `join("/repo")` fixture and a
+`/`-literal compared against `relative()` — and both were found by the platform, not by review.
+
+**The approval was being asked for the wrong thing.** A person clicking approve is deciding to make something
+irreversible. It is worth asking once the thing being published has been installed and driven where operators
+install it, and not before.
+
+**A shell was doing work no shell needed to do.** The probe was a `sh -c` script, which is why it could not run on
+Windows at all — and its earlier form joined the steps with `&&` and ended in `|| echo`, where `&&` and `||` share
+precedence, so any failure fell into the `||` and the compound exited 0. One process per step removes the
+composition rather than fixing it: there is nothing left to get the precedence of.
+
+**What the registry serves is not what this repository packed, until someone checks.** Every step before the
+publish reads a tarball built here. 0.3.2 is the case where those two differed. There is no rollback — versions are
+immutable and moving `latest` needs a token, which trusted publishing does not cover — so the post-publish probe
+cannot save a release. What it changes is who finds out: a red run in minutes instead of an operator days later,
+and the recovery is the next patch, which this pipeline ships in minutes.
+
+**And the inert scope had no counterpart.** `fix(gate)` never releases, by design: `ci`, `gate`, `release`, `docs`
+and `deps-dev` are repository plumbing, and three versions were published for that kind of work before the rule
+existed ([/decisions/ad-087.md](/decisions/ad-087.md)). Nothing checked the claim. A commit scoped `gate` fixed
+`tools/doctor.ts` — a file the package ships — and earned nothing; it reached operators only because an unrelated
+`fix` happened to be sitting on `main` to carry it. That is the same shape as a `perf` change that sat unreleased
+waiting for someone else's fix ([/decisions/ad-098.md](/decisions/ad-098.md)), and the check is calibrated against
+the real commit: it reports that one and stays silent on `chore(release)`, which has to stay inert.
+
+## Trade-offs
+
+**Each room is weaker; the coverage is wider.** A throwaway npm prefix shares the host filesystem, which a container
+did not. On a CI runner the whole machine is already throwaway, and the scratch `HOME`/`USERPROFILE` is what keeps a
+local run from touching the operator's own install — so what was lost is isolation from a machine nobody keeps, and
+what was gained is two platforms.
+
+**The post-publish probe cannot prevent anything.** Named in the workflow and here, because a check reported as
+stronger than it is would be worse than none.
+
+**`check-scopes` asks npm what ships.** Reading the `files` globs by hand would be a second implementation of npm's
+semantics, wrong in the safe-looking direction. The cost is that the check needs npm and a commit range, so it runs
+on the pull request rather than in `tlc harness test`.
+
+**Documentation is exempt by rule, not by judgement.** `docs/` and every `.md` file ship and change no behaviour, so
+`fix(docs)` over them is telling the truth. A doc-only edit *inside* a code file is not exempt, and that is
+deliberate: the type `docs:` already releases nothing, so the scope is unnecessary there.
+
+**Three platforms, twice, is about six runner-minutes per release.** Standard runners are free on public
+repositories, and the alternative was an operator finding it.
+
+## Not decided here
+
+- **A rollback.** None exists that is tokenless: versions are immutable and `npm dist-tag` is outside trusted
+  publishing. The recovery remains the next patch.
+- **A staged rollout or canary percentage.** npm has no such mechanism for a `latest` install, and the two shapes
+  that came closest were measured and rejected ([/decisions/ad-102.md](/decisions/ad-102.md)).
+- **Verifying on a platform the package does not claim.** `engines` is Node >= 24 and `os` is unrestricted; the
+  three runners are what CI offers.
+- **Whether an inert scope should release when it touches shipped code.** The check refuses the commit; it does not
+  quietly reclassify it. Deciding what a change is remains the author's.

--- a/docs/decisions/ad-103.md
+++ b/docs/decisions/ad-103.md
@@ -59,6 +59,26 @@ existed ([/decisions/ad-087.md](/decisions/ad-087.md)). Nothing checked the clai
 waiting for someone else's fix ([/decisions/ad-098.md](/decisions/ad-098.md)), and the check is calibrated against
 the real commit: it reports that one and stays silent on `chore(release)`, which has to stay inert.
 
+## Measured while building it
+
+**The verification broke a live machine, in the exact class it exists to prevent.** The probe's environment was
+`{...process.env, HOME, USERPROFILE}`. `tlc harness install` writes provider hooks into whatever
+`CLAUDE_CONFIG_DIR` and `CURSOR_CONFIG_DIR` resolve to, and this script inherited both from the shell — so a run
+inside an agent session rewrote the operator's real `settings.json`, and the skill link beside it, to point at a
+temp directory the script then deleted. Every hook on that machine failed to load with `MODULE_NOT_FOUND`.
+
+The suite has had a list of exactly these names since two defects of the same shape landed in one afternoon
+([/decisions/ad-102.md](/decisions/ad-102.md)), and the list's own comment names this outcome. The release script
+built its environment by hand and used none of it. It now builds the child's environment from those lists —
+destinations redirected into the throwaway, which-project and which-source names deleted — and the rail fails five
+tests when the old shape is restored.
+
+**And the leak was hiding the answer as well as breaking the machine.** With the real `TLC_HOME` inherited, the
+first probe step could resolve the operator's installed runtime rather than the tarball's, which is a verification
+reporting on the wrong artefact. Once closed, the same step correctly refuses on a machine whose shell `node` is
+22: a freshly installed copy has no runtime home yet, so it runs its own bundles, and the package's `engines` says
+Node >= 24. The CI runners are on 24, which is why three platforms passed there and this machine does not.
+
 ## Trade-offs
 
 **Each room is weaker; the coverage is wider.** A throwaway npm prefix shares the host filesystem, which a container

--- a/docs/decisions/ad-103.md
+++ b/docs/decisions/ad-103.md
@@ -74,10 +74,16 @@ destinations redirected into the throwaway, which-project and which-source names
 tests when the old shape is restored.
 
 **And the leak was hiding the answer as well as breaking the machine.** With the real `TLC_HOME` inherited, the
-first probe step could resolve the operator's installed runtime rather than the tarball's, which is a verification
-reporting on the wrong artefact. Once closed, the same step correctly refuses on a machine whose shell `node` is
-22: a freshly installed copy has no runtime home yet, so it runs its own bundles, and the package's `engines` says
-Node >= 24. The CI runners are on 24, which is why three platforms passed there and this machine does not.
+first probe step could resolve the operator's installed runtime rather than the tarball's — a verification
+reporting on the wrong artefact.
+
+**Then the fix over-reached, and the fix's own rail is what says where the line is.** Redirecting `TLC_HOME` and
+`TLC_INSTALL_DEST` into the throwaway alongside `HOME` made the launcher look for its runtime *there* — an empty
+directory, because `install` has not run yet at that step — and the probe died with `dist/tlc-cli.mjs is missing`
+on all three platforms at once. The suite redirects those two because it runs this code in-process against fake
+paths. An installed command has to resolve its own runtime out of the package it came from, so here they must be
+absent: any value answers that question for it. Same list, two behaviours, and the difference is which of the two
+is running the code.
 
 ## Trade-offs
 

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -110,6 +110,7 @@ Handoff section and a link back to this index.
 | [AD-100](/decisions/ad-100.md) | The operator declares the trigger and the proof; the harness enforces it | active |
 | [AD-101](/decisions/ad-101.md) | Machine data belongs to the machine, not to the install | active |
 | [AD-102](/decisions/ad-102.md) | A green gate is not a working product, so four checks that look where it cannot | active |
+| [AD-103](/decisions/ad-103.md) | The artefact is proven where operators install it, and an inert scope has to be telling the truth | active |
 
 ## Archived
 

--- a/docs/log.md
+++ b/docs/log.md
@@ -18,6 +18,7 @@ newest first. For what landed in which npm release, see `CHANGELOG.md` at the re
 - **AD-100** — The operator declares the trigger and the proof; the harness enforces it ([/decisions/ad-100.md](/decisions/ad-100.md))
 - **AD-101** — Machine data belongs to the machine, not to the install ([/decisions/ad-101.md](/decisions/ad-101.md))
 - **AD-102** — A green gate is not a working product, so four checks that look where it cannot ([/decisions/ad-102.md](/decisions/ad-102.md))
+- **AD-103** — The artefact is proven where operators install it, and an inert scope has to be telling the truth ([/decisions/ad-103.md](/decisions/ad-103.md))
 
 ## 2026-08-20
 

--- a/tools/__test__/check-scopes.test.ts
+++ b/tools/__test__/check-scopes.test.ts
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, test } from "node:test";
+import { changesBehaviour, decidingScope, violations } from "../dev/check-scopes.ts";
+
+/**
+ * AC — an inert scope claims the change cannot reach anyone who installed the package. `fix(gate)` on
+ * `tools/doctor.ts` is that claim being false, and it happened ([/decisions/ad-103.md](/decisions/ad-103.md)).
+ */
+describe("decidingScope", () => {
+  test("a releasing type with an inert scope is what this check is about", () => {
+    assert.equal(decidingScope("fix(gate): something"), "gate");
+    assert.equal(decidingScope("feat(ci): something"), "ci");
+    assert.equal(decidingScope("perf(release): something"), "release");
+  });
+
+  /**
+   * invariant: the release bot's own commit stays inert — that is what stops the pipeline releasing itself for
+   * ever — so a type that never releases has no scope worth reading.
+   */
+  test("a type that never releases is not a scope question at all", () => {
+    assert.equal(decidingScope("chore(release): 0.4.3"), null);
+    assert.equal(decidingScope("docs(rules): explain it"), null);
+    assert.equal(decidingScope("build(gate): rewire"), null);
+  });
+
+  test("a subject that is not conventional at all decides nothing", () => {
+    assert.equal(decidingScope("wip"), null);
+  });
+
+  test("a releasing type with no scope is never inert", () => {
+    assert.equal(decidingScope("fix: something"), null);
+  });
+});
+
+describe("changesBehaviour", () => {
+  /** invariant: documentation ships and changes no behaviour, so touching it is never evidence against a scope. */
+  test("documentation is exempt", () => {
+    assert.equal(changesBehaviour("README.md"), false);
+    assert.equal(changesBehaviour("docs/concepts.md"), false);
+    assert.equal(changesBehaviour("skills/harness-init/SKILL.md"), false);
+  });
+
+  test("code is not", () => {
+    assert.equal(changesBehaviour("tools/doctor.ts"), true);
+    assert.equal(changesBehaviour("src/core/core.facade.ts"), true);
+    assert.equal(changesBehaviour("capabilities/catalog.json"), true);
+  });
+});
+
+/**
+ * The range walk, against a real repository rather than a stub: the defect this check exists for was invisible to
+ * every assertion that read source instead of running it ([/decisions/ad-102.md](/decisions/ad-102.md)).
+ */
+describe("violations", () => {
+  function repo(): string {
+    const root = mkdtempSync(join(tmpdir(), "tlc-scopes-"));
+    const git = (...args: string[]) => execFileSync("git", args, { cwd: root, encoding: "utf8" });
+    git("init", "-q", "-b", "main");
+    git("config", "user.email", "test@example.com");
+    git("config", "user.name", "test");
+    writeFileSync(join(root, "seed"), "seed", "utf8");
+    git("add", "-A");
+    git("commit", "-q", "-m", "chore: seed");
+    return root;
+  }
+
+  function commit(root: string, subject: string, path: string): void {
+    writeFileSync(join(root, path), subject, "utf8");
+    execFileSync("git", ["add", "-A"], { cwd: root });
+    execFileSync("git", ["commit", "-q", "-m", subject], { cwd: root });
+  }
+
+  const published = new Set(["ships.ts", "README.md"]);
+
+  test("an inert scope over a shipped file is reported, with the file named", () => {
+    const root = repo();
+    commit(root, "fix(gate): quietly changes what operators run", "ships.ts");
+
+    const found = violations("HEAD~1..HEAD", published, root);
+
+    assert.equal(found.length, 1);
+    assert.equal(found[0]?.scope, "gate");
+    assert.deepEqual(found[0]?.paths, ["ships.ts"]);
+  });
+
+  test("the same scope over a file the package does not ship is fine", () => {
+    const root = repo();
+    commit(root, "fix(gate): plumbing only", "not-shipped.ts");
+
+    assert.deepEqual(violations("HEAD~1..HEAD", published, root), []);
+  });
+
+  test("and over documentation it ships, also fine", () => {
+    const root = repo();
+    commit(root, "fix(docs): a typo", "README.md");
+
+    assert.deepEqual(violations("HEAD~1..HEAD", published, root), []);
+  });
+
+  test("an empty range reports nothing rather than failing", () => {
+    assert.deepEqual(violations("HEAD..HEAD", published, repo()), []);
+  });
+});

--- a/tools/__test__/release-workflow.test.ts
+++ b/tools/__test__/release-workflow.test.ts
@@ -210,12 +210,98 @@ describe("the packed artefact is verified before the irreversible step", () => {
     assert.ok(verify < registry, "verification must precede anything reaching the registry");
   });
 
-  /** why asserted: the payload list is the half that runs before anything is installed, and it is easy to gut. */
-  test("the verification asserts the payload and drives the installed command", () => {
+  /**
+   * why the payload assertion is executed and not read: this test used to search the script's source for the paths
+   * it requires, which is the pattern an independent review already broke twice — and when the payload list moved
+   * from tar's `package/…` prefix to npm's own answer, the source search failed on a correct script
+   * ([/decisions/ad-102.md](/decisions/ad-102.md), [/decisions/ad-103.md](/decisions/ad-103.md)).
+   *
+   * why a child process: the check exits rather than throwing, because it guards a release rather than a caller.
+   */
+  function payloadVerdict(entries: string[]) {
+    const script = join(repoRoot, "tools", "dev", "verify-package.mjs").replaceAll("\\", "/");
+    const probe = spawnSync(
+      process.execPath,
+      ["-e", `import("file://${script}").then((m) => m.assertPayload(${JSON.stringify(entries)}))`],
+      { encoding: "utf8" },
+    );
+    return { status: probe.status, output: `${probe.stdout ?? ""}${probe.stderr ?? ""}` };
+  }
+
+  const complete = [
+    "package.json",
+    "bin/tlc",
+    "bin/tlc.mjs",
+    "bin/tlc-exec.mjs",
+    "dist/tool-before.mjs",
+    "skills/harness-init/SKILL.md",
+  ];
+
+  test("a payload with everything the runtime needs passes", () => {
+    assert.equal(payloadVerdict(complete).status, 0);
+  });
+
+  test("a payload missing the launcher fails, and says which path", () => {
+    const verdict = payloadVerdict(complete.filter((path) => path !== "bin/tlc"));
+
+    assert.notEqual(verdict.status, 0);
+    assert.match(verdict.output, /bin\/tlc/);
+  });
+
+  test("a payload that ships this repository's own checks fails", () => {
+    const verdict = payloadVerdict([...complete, "tools/dev/check-scopes.ts"]);
+
+    assert.notEqual(verdict.status, 0);
+    assert.match(verdict.output, /must not/);
+  });
+
+  /** invariant: the command an operator is told to trust is driven, not merely installed. */
+  test("and the clean room drives doctor", () => {
     const script = readFileSync(join(repoRoot, "tools", "dev", "verify-package.mjs"), "utf8");
 
-    for (const required of ["package/bin/tlc", "package/dist/tool-before.mjs", "tlc harness doctor"]) {
-      assert.ok(script.includes(required), `the verification no longer checks ${required}`);
+    assert.match(script, /command: "tlc harness doctor"/);
+  });
+});
+
+/**
+ * The artefact used to be installed and driven on Linux alone, in a container that exists nowhere else — while every
+ * defect that reached an operator was an install defect, and install is the most platform-shaped code in the package
+ * ([/decisions/ad-103.md](/decisions/ad-103.md)).
+ */
+describe("the artefact is proven on every platform the package claims", () => {
+  test("a job packs and drives it on all three", () => {
+    const verify = workflow.indexOf("\n  verify:");
+    assert.ok(verify > 0, "there is a verify job");
+
+    const job = workflow.slice(verify, workflow.indexOf("\n  release:"));
+    for (const runner of ["ubuntu-latest", "macos-latest", "windows-latest"]) {
+      assert.ok(job.includes(runner), `${runner} is not verified`);
+    }
+    assert.match(job, /node tools\/dev\/verify-package\.mjs/);
+  });
+
+  /**
+   * invariant: the approval lives on `release`, so making `release` depend on the matrix is what puts the proof
+   * before the person. A job that runs in parallel with the publish would prove nothing in time.
+   */
+  test("and the job that publishes cannot start without it", () => {
+    assert.match(workflow, /release:\n\s+needs: \[gate, decide, verify\]/);
+  });
+
+  /**
+   * why after the publish too: everything before it reads a tarball built here, and what an operator installs is
+   * what the registry serves. It cannot prevent — there is no rollback — but it turns "a person finds it days
+   * later" into "the run goes red in minutes".
+   */
+  test("the published version is installed from the registry and driven", () => {
+    const smoke = workflow.indexOf("\n  smoke:");
+    assert.ok(smoke > 0, "there is a smoke job");
+
+    const job = workflow.slice(smoke);
+    assert.match(job, /needs: \[decide, release\]/);
+    assert.match(job, /verify-package\.mjs --from/);
+    for (const runner of ["ubuntu-latest", "macos-latest", "windows-latest"]) {
+      assert.ok(job.includes(runner), `${runner} never drives the published version`);
     }
   });
 });

--- a/tools/__test__/verify-package.test.ts
+++ b/tools/__test__/verify-package.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, test } from "node:test";
@@ -66,19 +67,27 @@ describe("probeSteps", () => {
  */
 describe("runSteps", () => {
   /**
-   * invariant: "nothing after the failure runs" is proven by a step that would leave a file behind, not by an
-   * assertion about a variable this test controls.
+   * hazard: the negative half of this test — "the marker is absent, so nothing after the failure ran" — proves
+   * nothing on its own. If the marker command were broken, by quoting on one platform or by a typo, the assertion
+   * would pass for the wrong reason and the test would never fail. So the same step runs alone first and has to
+   * write; only then is its absence evidence ([/decisions/ad-103.md](/decisions/ad-103.md)).
    */
   test("a failure stops the run and names the step that failed", () => {
     const marker = join(mkdtempSync(join(tmpdir(), "tlc-steps-")), "reached");
+    const writes = {
+      label: "the marker step",
+      command: `node -e "require('fs').writeFileSync(process.argv[1],'x')" ${marker}`,
+    };
+
+    assert.equal((runSteps([writes], {}) as { ok: boolean }).ok, true, "the marker step must run at all");
+    assert.equal(existsSync(marker), true, "the marker step must write when it is reached");
+    rmSync(marker);
+
     const result = runSteps(
       [
         { label: "first", command: 'node -e "console.log(1)"' },
         { label: "the one that fails", command: 'node -e "process.exit(3)"' },
-        {
-          label: "unreachable",
-          command: `node -e "require('fs').writeFileSync(process.argv[1],'x')" ${marker}`,
-        },
+        { ...writes, label: "unreachable" },
       ],
       {},
     ) as { ok: boolean; step?: { label: string }; reason?: string };
@@ -242,10 +251,56 @@ describe("the published-version probe", () => {
     assert.equal(parsed.version, "1.2.3");
   });
 
-  test("retries are only what argv actually says", () => {
-    assert.equal(attempts(["--retries", "6"]), 6);
-    assert.equal(attempts(["--retries", "nonsense"]), 0);
+  test("no --retries means no retries, which is not the same as an unreadable one", () => {
     assert.equal(attempts(["--from", "a@1"]), 0);
+    assert.equal(attempts(["--retries", "6"]), 6);
+  });
+
+  /**
+   * hazard: the separator was found with `lastIndexOf("@")`, so `@scope/pkg` — this package's own shape — read as
+   * version `scope/pkg` and walked past the guard written to stop it. The probe would then install whatever
+   * `latest` happened to be and fail three steps later against a version nobody asked for.
+   *
+   * why a child process: these guards exit rather than throw, because they guard a release rather than a caller
+   * ([/decisions/ad-103.md](/decisions/ad-103.md)).
+   */
+  describe("an argument that cannot mean what it says is fatal, not silently ignored", () => {
+    function verdict(args: string[], call: string) {
+      const script = join(
+        dirname(fileURLToPath(import.meta.url)),
+        "..",
+        "dev",
+        "verify-package.mjs",
+      ).replaceAll("\\", "/");
+      const probe = spawnSync(
+        process.execPath,
+        ["-e", `import("file://${script}").then((m) => m.${call}(${JSON.stringify(args)}))`],
+        { encoding: "utf8" },
+      );
+      return { status: probe.status, output: `${probe.stdout ?? ""}${probe.stderr ?? ""}` };
+    }
+
+    for (const spec of ["@scope/pkg", "pkg", "@scope/pkg@"]) {
+      test(`--from ${spec} is refused`, () => {
+        const result = verdict(["--from", spec], "registrySpec");
+
+        assert.notEqual(result.status, 0, result.output);
+        assert.match(result.output, /needs <name@version>/);
+      });
+    }
+
+    test("--from @scope/pkg@1.2.3 is accepted", () => {
+      assert.equal(verdict(["--from", "@scope/pkg@1.2.3"], "registrySpec").status, 0);
+    });
+
+    for (const given of ["nonsense", "6.9", "-2"]) {
+      test(`--retries ${given} is refused`, () => {
+        const result = verdict(["--retries", given], "attempts");
+
+        assert.notEqual(result.status, 0, result.output);
+        assert.match(result.output, /needs a whole number/);
+      });
+    }
   });
 });
 

--- a/tools/__test__/verify-package.test.ts
+++ b/tools/__test__/verify-package.test.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, test } from "node:test";
 import { fileURLToPath } from "node:url";
-import { composeProbe, probeCommands } from "../dev/verify-package.mjs";
+import { attempts, parsePackReport, probeSteps, registrySpec, runSteps } from "../dev/verify-package.mjs";
 
 /**
  * hazard: an independent review deleted the `tlc harness doctor` line from the probe and every test stayed green,
@@ -13,10 +13,15 @@ import { composeProbe, probeCommands } from "../dev/verify-package.mjs";
  * ` && ` and ended in `|| echo`, and `&&` and `||` share precedence, so any failure fell into the `||` and the
  * compound exited 0 ([/decisions/ad-102.md](/decisions/ad-102.md)).
  */
-describe("probeCommands", () => {
-  const commands = probeCommands("pkg-1.0.0.tgz", "1.0.0");
+describe("probeSteps", () => {
+  const steps = probeSteps("/tmp/pkg-1.0.0.tgz", "1.0.0") as {
+    label: string;
+    command: string;
+    expect?: string;
+  }[];
+  const commands = steps.map((step) => step.command);
 
-  /** invariant: asserted element by element, so a deleted command cannot hide inside another one's text. */
+  /** invariant: asserted element by element, so a deleted step cannot hide inside another one's text. */
   test("the clean room installs, then drives every command an operator would", () => {
     assert.ok(commands.includes("tlc harness version"), commands.join(" | "));
     assert.ok(commands.includes("tlc harness install"), commands.join(" | "));
@@ -24,49 +29,141 @@ describe("probeCommands", () => {
   });
 
   test("it installs the tarball it was given, the way npx would", () => {
-    assert.equal(commands[0], "npm i -g /work/pkg-1.0.0.tgz --silent");
+    assert.equal(steps[0]?.command, 'npm i -g "/tmp/pkg-1.0.0.tgz" --silent');
   });
 
+  /**
+   * invariant: the version is read back out of the installed runtime, and as an expectation on captured output
+   * rather than a `grep` pipeline — `grep` is not a command on Windows, and a pipeline's exit status was the other
+   * half of the swallowed-failure defect ([/decisions/ad-103.md](/decisions/ad-103.md)).
+   */
   test("and reads the version back out of the installed runtime", () => {
-    assert.ok(
-      commands.some((command) => command.includes("grep -q") && command.includes("1.0.0")),
-      commands.join(" | "),
-    );
+    const doctor = steps.find((step) => step.command === "tlc harness doctor");
+
+    assert.equal(doctor?.expect, "harness version — 1.0.0");
+  });
+
+  /** invariant: no step composes a shell — one process per step is what removed the swallowed-failure class. */
+  test("no step carries a shell operator", () => {
+    for (const command of commands) {
+      assert.doesNotMatch(command, /&&|\|\||\|/, command);
+    }
   });
 });
 
 /**
- * The composition rule, executed rather than read: the first failure must be the exit status, and nothing after it
- * may run.
+ * The composition rule, executed rather than read: the first failure must stop the run, and a step that exits 0
+ * while reporting the wrong thing must fail too.
  */
-describe("composeProbe", () => {
-  function shell(script: string) {
-    const result = spawnSync("sh", ["-c", script], { encoding: "utf8" });
-    return { status: result.status, stdout: result.stdout ?? "" };
-  }
+describe("runSteps", () => {
+  /**
+   * invariant: "nothing after the failure runs" is proven by a step that would leave a file behind, not by an
+   * assertion about a variable this test controls.
+   */
+  test("a failure stops the run and names the step that failed", () => {
+    const marker = join(mkdtempSync(join(tmpdir(), "tlc-steps-")), "reached");
+    const result = runSteps(
+      [
+        { label: "first", command: 'node -e "console.log(1)"' },
+        { label: "the one that fails", command: 'node -e "process.exit(3)"' },
+        {
+          label: "unreachable",
+          command: `node -e "require('fs').writeFileSync(process.argv[1],'x')" ${marker}`,
+        },
+      ],
+      {},
+    ) as { ok: boolean; step?: { label: string }; reason?: string };
 
-  test("a failure anywhere stops the run and is the exit status", () => {
-    const result = shell(composeProbe(["true", "false", "echo unreachable"]));
-
-    assert.notEqual(result.status, 0);
-    assert.doesNotMatch(result.stdout, /unreachable/, "nothing after the failure may run");
+    assert.equal(result.ok, false);
+    assert.equal(result.step?.label, "the one that fails");
+    assert.match(result.reason ?? "", /exit 3/);
+    assert.equal(existsSync(marker), false, "nothing after the failure may run");
   });
 
-  test("a failing pipeline is a failure too, not a swallowed one", () => {
-    const result = shell(composeProbe(['echo nothing | grep -q "absent"']));
+  /**
+   * hazard: this is the case a chained shell script could not see at all. `doctor` exits 0 while reporting a
+   * version that is not the one being published — a shim resolving an older runtime does exactly that.
+   */
+  test("a step that exits 0 with the wrong output fails", () => {
+    const result = runSteps(
+      [{ label: "wrong version", command: "node -e \"console.log('0.0.1')\"", expect: "9.9.9" }],
+      {},
+    ) as { ok: boolean; reason?: string };
 
-    assert.notEqual(result.status, 0);
+    assert.equal(result.ok, false);
+    assert.match(result.reason ?? "", /does not contain/);
   });
 
-  test("and a clean run is zero", () => {
-    assert.equal(shell(composeProbe(["true", "echo fine"])).status, 0);
+  test("and a clean run is ok", () => {
+    const result = runSteps(
+      [{ label: "fine", command: "node -e \"console.log('ready')\"", expect: "ready" }],
+      {},
+    ) as {
+      ok: boolean;
+    };
+
+    assert.equal(result.ok, true);
   });
 });
 
 /**
- * hazard: this module's main flow ran at module scope, so importing it to test `probeCommands` executed `npm pack`
- * and the whole container probe. It passed locally and failed the macOS leg of CI with a file-level error at line 1
- * — the module, not a test. The rule already existed: no library module self-executes
+ * hazard: `prepack` runs the bundler, so this stdout is not only npm's report — and the bundler colours its output,
+ * which means an ANSI escape's own `[` is what a scan for the first bracket finds
+ * ([/decisions/ad-103.md](/decisions/ad-103.md)).
+ */
+describe("parsePackReport", () => {
+  const report =
+    '{\n  "@scope/pkg": {\n    "filename": "scope-pkg-1.0.0.tgz",\n    "files": [{ "path": "bin/tlc" }]\n  }\n}';
+
+  test("noise before the report does not hide it", () => {
+    const parsed = parsePackReport(
+      `tlc-build → /repo/dist\n[32mBundled 125 modules in 9ms[0m\n${report}`,
+    ) as {
+      filename: string;
+    };
+
+    assert.equal(parsed.filename, "scope-pkg-1.0.0.tgz");
+  });
+
+  test("the array shape npm also uses is read the same way", () => {
+    const parsed = parsePackReport('noise\n[\n  { "filename": "a-1.0.0.tgz" }\n]') as { filename: string };
+
+    assert.equal(parsed.filename, "a-1.0.0.tgz");
+  });
+
+  test("no report at all is null rather than a throw", () => {
+    assert.equal(parsePackReport("npm error code E404\n"), null);
+  });
+});
+
+/**
+ * The post-publish probe reads its target and its patience from argv, and both have a failure mode that is silent:
+ * a spec with no version would drive whatever `latest` happens to be, and a retry count nothing parses would make
+ * the flag in the workflow decorative ([/decisions/ad-103.md](/decisions/ad-103.md)).
+ */
+describe("the published-version probe", () => {
+  test("no --from means the local tarball, not the registry", () => {
+    assert.equal(registrySpec(["node", "verify-package.mjs"]), null);
+  });
+
+  test("a spec carries the version it will assert on", () => {
+    const parsed = registrySpec(["--from", "@scope/pkg@1.2.3"]) as { spec: string; version: string };
+
+    assert.equal(parsed.spec, "@scope/pkg@1.2.3");
+    assert.equal(parsed.version, "1.2.3");
+  });
+
+  test("retries are only what argv actually says", () => {
+    assert.equal(attempts(["--retries", "6"]), 6);
+    assert.equal(attempts(["--retries", "nonsense"]), 0);
+    assert.equal(attempts(["--from", "a@1"]), 0);
+  });
+});
+
+/**
+ * hazard: this module's main flow ran at module scope, so importing it to test the steps executed `npm pack` and the
+ * whole probe. It passed locally and failed the macOS leg of CI with a file-level error at line 1 — the module, not
+ * a test. The rule already existed: no library module self-executes
  * ([/decisions/ad-098.md](/decisions/ad-098.md), [/decisions/ad-102.md](/decisions/ad-102.md)).
  */
 test("importing the module runs nothing", () => {
@@ -77,25 +174,7 @@ test("importing the module runs nothing", () => {
   const guard = source.indexOf("if (import.meta.main) {");
 
   assert.ok(guard > 0, "the main flow must sit behind an import.meta.main guard");
-  assert.doesNotMatch(
-    source.slice(0, guard),
-    /^(npm|const packed|const tarball)\b/m,
-    "nothing above the guard may act",
-  );
-});
-
-/**
- * invariant: and the guard is asserted by behaviour too — a child process that imports the module must exit clean
- * without packing anything, which is the failure CI saw.
- */
-test("a process that only imports it exits clean", () => {
-  const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
-  const result = spawnSync(
-    process.execPath,
-    ["-e", 'import("./tools/dev/verify-package.mjs").then(() => process.exit(0))'],
-    { cwd: repoRoot, encoding: "utf8", timeout: 30_000 },
-  );
-
-  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
-  assert.doesNotMatch(`${result.stdout}`, /payload ok|clean room/, "importing must not run the probe");
+  // why unindented: an indented declaration is inside a function, which is where spawning belongs. Only a
+  // module-scope one executes on import, and that is the defect this rail exists for.
+  assert.doesNotMatch(source.slice(0, guard), /^(?:const|let)\s+\w+\s*=\s*(?:run|spawnSync)\(/m);
 });

--- a/tools/__test__/verify-package.test.ts
+++ b/tools/__test__/verify-package.test.ts
@@ -4,7 +4,14 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, test } from "node:test";
 import { fileURLToPath } from "node:url";
-import { attempts, parsePackReport, probeEnv, probeSteps, registrySpec, runSteps } from "../dev/verify-package.mjs";
+import {
+  attempts,
+  parsePackReport,
+  probeEnv,
+  probeSteps,
+  registrySpec,
+  runSteps,
+} from "../dev/verify-package.mjs";
 import { REDIRECTED_ENV } from "../test-env.names.mjs";
 
 /**

--- a/tools/__test__/verify-package.test.ts
+++ b/tools/__test__/verify-package.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, test } from "node:test";
 import { fileURLToPath } from "node:url";
+import { normalizeSeparators } from "../../src/platform/sanitize.ts";
 import {
   attempts,
   parsePackReport,
@@ -209,9 +210,12 @@ describe("probeEnv", () => {
   test("every declared destination is covered", () => {
     for (const name of REDIRECTED_ENV) {
       const value = env[name];
+      // why normalised: `join` spells these with the platform's separator, so a `/tmp/` prefix test is an
+      // assertion about the developer's platform rather than about the value — which is the third time this
+      // separator class has been caught by the Windows leg ([/decisions/ad-102.md](/decisions/ad-102.md)).
       assert.ok(
-        value === undefined || value.startsWith("/tmp/"),
-        `${name} is neither absent nor inside the throwaway`,
+        value === undefined || normalizeSeparators(value).startsWith("/tmp/"),
+        `${name} is neither absent nor inside the throwaway: ${value}`,
       );
     }
   });

--- a/tools/__test__/verify-package.test.ts
+++ b/tools/__test__/verify-package.test.ts
@@ -191,12 +191,28 @@ describe("probeEnv", () => {
   });
 
   /**
-   * invariant: every name the suite declares as a redirected destination gets a value here. A name added to that
-   * list and not to this map would keep pointing at the operator's own path.
+   * hazard: pointing these at the throwaway made the launcher look for the runtime there — an empty directory,
+   * because `install` has not run yet at that step — and the probe died with "dist/tlc-cli.mjs is missing" on all
+   * three platforms. An installed command has to resolve its own runtime out of the package it came from, and any
+   * value here answers that question for it ([/decisions/ad-103.md](/decisions/ad-103.md)).
+   */
+  test("the names that would tell the launcher where its runtime is are absent, not redirected", () => {
+    assert.equal(env.TLC_HOME, undefined);
+    assert.equal(env.TLC_INSTALL_DEST, undefined);
+  });
+
+  /**
+   * invariant: every name the suite declares as a redirected destination is either inside the throwaway or
+   * deliberately absent. A name added to that list and handled by neither would keep pointing at the operator's
+   * own path.
    */
   test("every declared destination is covered", () => {
     for (const name of REDIRECTED_ENV) {
-      assert.ok((env[name] ?? "").startsWith("/tmp/"), `${name} is not inside the throwaway`);
+      const value = env[name];
+      assert.ok(
+        value === undefined || value.startsWith("/tmp/"),
+        `${name} is neither absent nor inside the throwaway`,
+      );
     }
   });
 

--- a/tools/__test__/verify-package.test.ts
+++ b/tools/__test__/verify-package.test.ts
@@ -4,7 +4,8 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, test } from "node:test";
 import { fileURLToPath } from "node:url";
-import { attempts, parsePackReport, probeSteps, registrySpec, runSteps } from "../dev/verify-package.mjs";
+import { attempts, parsePackReport, probeEnv, probeSteps, registrySpec, runSteps } from "../dev/verify-package.mjs";
+import { REDIRECTED_ENV } from "../test-env.names.mjs";
 
 /**
  * hazard: an independent review deleted the `tlc harness doctor` line from the probe and every test stayed green,
@@ -133,6 +134,67 @@ describe("parsePackReport", () => {
 
   test("no report at all is null rather than a throw", () => {
     assert.equal(parsePackReport("npm error code E404\n"), null);
+  });
+});
+
+/**
+ * hazard: the probe's environment was `{...process.env, HOME, USERPROFILE}`. `tlc harness install` writes provider
+ * hooks into whatever `CLAUDE_CONFIG_DIR` and `CURSOR_CONFIG_DIR` resolve to, and those were inherited from the
+ * shell — so running this script inside an agent session rewrote the operator's real `settings.json` to point at a
+ * temp directory the script then deleted, and every hook on that machine failed to load. The suite's own list of
+ * these names already existed ([/decisions/ad-102.md](/decisions/ad-102.md), [/decisions/ad-103.md](/decisions/ad-103.md)).
+ */
+describe("probeEnv", () => {
+  const real = {
+    HOME: "/home/operator",
+    USERPROFILE: "C:\\Users\\operator",
+    CLAUDE_CONFIG_DIR: "/home/operator/.claude-work",
+    CURSOR_CONFIG_DIR: "/home/operator/.cursor",
+    TLC_HOME: "/home/operator/.tlc/harness",
+    TLC_INSTALL_DEST: "/home/operator/.tlc/harness",
+    TLC_BIN_DIR: "/home/operator/.local/bin",
+    TLC_ORIGIN: "/repo",
+    TLC_HOME_FROM_ENV: "1",
+    CLAUDE_PROJECT_DIR: "/repo",
+    CURSOR_PROJECT_DIR: "/repo",
+    TLC_PROJECT_DIR: "/repo",
+    PATH: "/usr/bin",
+  };
+  const env = probeEnv(real, "/tmp/prefix", "/tmp/home") as Record<string, string | undefined>;
+
+  /** invariant: nothing the child can write may name a path outside the throwaway. */
+  test("no destination still points at the operator's own paths", () => {
+    for (const [name, value] of Object.entries(env)) {
+      if (name === "PATH") {
+        continue;
+      }
+      assert.doesNotMatch(value ?? "", /operator/, `${name} still names the operator's own path`);
+    }
+  });
+
+  test("the provider config directories are redirected, not inherited", () => {
+    assert.equal(env.CLAUDE_CONFIG_DIR, join("/tmp/home", ".claude"));
+    assert.equal(env.CURSOR_CONFIG_DIR, join("/tmp/home", ".cursor"));
+  });
+
+  test("which-project and which-source names are removed rather than pointed somewhere", () => {
+    for (const name of ["CLAUDE_PROJECT_DIR", "CURSOR_PROJECT_DIR", "TLC_PROJECT_DIR", "TLC_ORIGIN"]) {
+      assert.equal(env[name], undefined, `${name} survived`);
+    }
+  });
+
+  /**
+   * invariant: every name the suite declares as a redirected destination gets a value here. A name added to that
+   * list and not to this map would keep pointing at the operator's own path.
+   */
+  test("every declared destination is covered", () => {
+    for (const name of REDIRECTED_ENV) {
+      assert.ok((env[name] ?? "").startsWith("/tmp/"), `${name} is not inside the throwaway`);
+    }
+  });
+
+  test("and the installed command is found before anything already on PATH", () => {
+    assert.match(env.PATH ?? "", /^\/tmp\/prefix/);
   });
 });
 

--- a/tools/dev/check-scopes.ts
+++ b/tools/dev/check-scopes.ts
@@ -1,0 +1,116 @@
+/**
+ * An inert scope claims the change cannot reach anyone who installed the package. This checks the claim.
+ *
+ * why it exists: `fix(gate)` never releases, by design — `ci`, `gate`, `release`, `docs` and `deps-dev` are
+ * repository plumbing, and three versions were published for exactly that kind of work before the rule existed. The
+ * rule has no counterpart: nothing checked that a commit wearing an inert scope was actually plumbing. One that
+ * fixed `tools/doctor.ts` — a file the package ships — shipped anyway, because everything on `main` ships, and
+ * earned nothing. It only reached operators because an unrelated `fix` happened to be sitting there to carry it
+ * ([/decisions/ad-103.md](/decisions/ad-103.md), [/decisions/ad-098.md](/decisions/ad-098.md)).
+ *
+ * invariant: documentation is exempt. `docs/` and every `.md` file are in the published payload and change no
+ * behaviour, so a `docs`-scoped commit touching them is telling the truth.
+ *
+ * why a range and not the working tree: this reads commits, so it runs where a base exists — the pull request. It
+ * is not a step of `tlc harness test`, which has no base to compare against.
+ */
+import { execFileSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { INERT_SCOPES, MINOR_TYPES, PATCH_TYPES } from "../../src/core/release/release.version.ts";
+import { normalizeSeparators } from "../../src/platform/sanitize.ts";
+import { parsePackReport } from "./verify-package.mjs";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const SUBJECT = /^(?<type>[a-z]+)(?:\((?<scope>[^)]*)\))?(?<breaking>!)?:\s*(?<rest>.+)$/;
+
+/** Documentation ships and changes no behaviour, so touching it is never evidence against an inert scope. */
+export function changesBehaviour(path: string): boolean {
+  return !(path.endsWith(".md") || path.startsWith("docs/"));
+}
+
+/**
+ * The scope, but only where it decides anything.
+ *
+ * why the type is read too: an inert scope only matters on a type that would otherwise release. `chore(release)` is
+ * the release bot's own commit and has to stay inert — that is what stops the pipeline releasing itself for ever —
+ * and reporting it would be reporting the mechanism as the defect.
+ */
+export function decidingScope(subject: string): string | null {
+  const groups = SUBJECT.exec(subject.trim())?.groups;
+  if (groups === undefined) {
+    return null;
+  }
+  const releases = MINOR_TYPES.has(groups.type ?? "") || PATCH_TYPES.has(groups.type ?? "");
+  return releases ? (groups.scope ?? null) : null;
+}
+
+/**
+ * The paths npm would publish, as npm resolves them.
+ *
+ * why npm and not the `files` array read by hand: those globs have semantics — a bare directory means everything
+ * under it, `!` subtracts, and `**` is not the only wildcard. A second implementation of that is a second thing to
+ * be wrong, and it would be wrong in the safe-looking direction.
+ */
+export function publishedPaths(cwd: string): Set<string> {
+  const packed = execFileSync("npm", ["pack", "--dry-run", "--json", "--ignore-scripts"], {
+    cwd,
+    encoding: "utf8",
+    // why stderr is captured rather than inherited: npm narrates the dry run, and that narration is not the report.
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const report = parsePackReport(packed) as { files?: { path: string }[] } | null;
+  return new Set((report?.files ?? []).map((file) => file.path));
+}
+
+export type Violation = { sha: string; subject: string; scope: string; paths: string[] };
+
+export function violations(range: string, published: Set<string>, cwd: string): Violation[] {
+  const listed = execFileSync("git", ["log", range, "--format=%H"], { cwd, encoding: "utf8" }).trim();
+  const shas = listed.length === 0 ? [] : listed.split("\n");
+  const found: Violation[] = [];
+
+  for (const sha of shas) {
+    const subject = execFileSync("git", ["log", "-1", "--format=%s", sha], { cwd, encoding: "utf8" }).trim();
+    const scope = decidingScope(subject);
+    if (scope === null || !INERT_SCOPES.has(scope)) {
+      continue;
+    }
+    const touched = execFileSync("git", ["show", "--name-only", "--format=", sha], { cwd, encoding: "utf8" })
+      .split("\n")
+      .map((path) => normalizeSeparators(path.trim()))
+      .filter((path) => path.length > 0);
+    const shipped = touched.filter((path) => published.has(path) && changesBehaviour(path));
+    if (shipped.length > 0) {
+      found.push({ sha: sha.slice(0, 7), subject, scope, paths: shipped });
+    }
+  }
+  return found;
+}
+
+if (import.meta.main) {
+  const at = process.argv.indexOf("--base");
+  const base = at < 0 ? "origin/main" : (process.argv[at + 1] ?? "origin/main");
+  const published = publishedPaths(repoRoot);
+  const found = violations(`${base}..HEAD`, published, repoRoot);
+
+  if (found.length === 0) {
+    console.log(
+      `check-scopes: every inert scope in ${base}..HEAD touches only what the package does not ship`,
+    );
+    process.exit(0);
+  }
+
+  for (const violation of found) {
+    console.error(
+      `check-scopes: ${violation.sha} "${violation.subject}"\n` +
+        `  scope \`${violation.scope}\` never releases, but this commit changes code the package ships:\n` +
+        violation.paths.map((path) => `    ${path}`).join("\n"),
+    );
+  }
+  console.error(
+    "\nAn inert scope means an operator cannot reach the change. Use a scope that releases, or split the commit.",
+  );
+  process.exit(1);
+}

--- a/tools/dev/verify-package.d.mts
+++ b/tools/dev/verify-package.d.mts
@@ -15,5 +15,10 @@ export function assertPayload(entries: string[]): string[];
 export function probeSteps(tarball: string, version: string): ProbeStep[];
 export function parsePackReport(stdout: string): PackReport | null;
 export function runSteps(steps: ProbeStep[], options: Record<string, unknown>): ProbeResult;
+export function probeEnv(
+  base: Record<string, string | undefined>,
+  prefix: string,
+  home: string,
+): Record<string, string | undefined>;
 export function registrySpec(argv: string[]): { spec: string; version: string } | null;
 export function attempts(argv: string[]): number;

--- a/tools/dev/verify-package.d.mts
+++ b/tools/dev/verify-package.d.mts
@@ -1,3 +1,19 @@
-export function assertPayload(tarball: string): string[];
-export function probeCommands(tarball: string, version: string): string[];
-export function composeProbe(commands: readonly string[]): string;
+/**
+ * Types for a `.mjs` tool with two `.ts` callers: its own suite, and `check-scopes.ts`, which needs
+ * `parsePackReport` rather than a second implementation of "find npm's report on a stream that also carries the
+ * bundler's output".
+ */
+export type PackReport = { filename?: string; files?: { path: string }[] };
+
+export type ProbeStep = { label: string; command: string; expect?: string };
+
+export type ProbeResult =
+  | { ok: true; room?: string }
+  | { ok: false; step: ProbeStep; index: number; output: string; reason: string; room?: string };
+
+export function assertPayload(entries: string[]): string[];
+export function probeSteps(tarball: string, version: string): ProbeStep[];
+export function parsePackReport(stdout: string): PackReport | null;
+export function runSteps(steps: ProbeStep[], options: Record<string, unknown>): ProbeResult;
+export function registrySpec(argv: string[]): { spec: string; version: string } | null;
+export function attempts(argv: string[]): number;

--- a/tools/dev/verify-package.mjs
+++ b/tools/dev/verify-package.mjs
@@ -25,6 +25,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join, resolve } from "node:path";
+import { PROJECT_SCOPED_ENV, REDIRECTED_ENV, RUNTIME_SCOPED_ENV } from "../test-env.names.mjs";
 
 function fail(message) {
   console.error(`verify-package: ${message}`);
@@ -155,15 +156,47 @@ export function runSteps(steps, options) {
 }
 
 /**
- * why a prefix and not a real `npm i -g`: a real global install would replace the operator's own command, which is
- * exactly the class of defect this script exists to catch. The prefix keeps it to a throwaway directory.
+ * The child's environment: every name that says *where* pointed at the throwaway, and every name that says *which
+ * project* or *which runtime source* removed.
+ *
+ * hazard: this used to be `{...process.env, HOME, USERPROFILE}`. `tlc harness install` writes provider hooks into
+ * whatever `CLAUDE_CONFIG_DIR` and `CURSOR_CONFIG_DIR` resolve to, and this script inherited them from the shell —
+ * so a run inside an agent session rewrote the operator's real `settings.json` to point at a temp directory this
+ * function then deleted, and every hook on that machine failed to load. The suite has had a list for exactly this
+ * since two defects of the same shape landed in one afternoon; the release script built its environment by hand and
+ * used none of it ([/decisions/ad-102.md](/decisions/ad-102.md), [/decisions/ad-103.md](/decisions/ad-103.md)).
  *
  * why both `<prefix>` and `<prefix>/bin` are on PATH: npm puts the shim directly in the prefix on Windows and in
  * `bin/` everywhere else. Naming one of them is how a check passes on the platform it was written on and fails on
  * the other.
- *
- * why HOME and USERPROFILE both: `os.homedir()` reads the first on POSIX and the second on Windows, and the install
- * writes the runtime, the provider config and the launcher link under it.
+ */
+export function probeEnv(base, prefix, home) {
+  const env = { ...base };
+  for (const name of [...PROJECT_SCOPED_ENV, ...RUNTIME_SCOPED_ENV]) {
+    delete env[name];
+  }
+  const destinations = {
+    HOME: home,
+    USERPROFILE: home,
+    TLC_HOME: join(home, ".tlc", "harness"),
+    TLC_INSTALL_DEST: join(home, ".tlc", "harness"),
+    TLC_BIN_DIR: join(home, ".local", "bin"),
+    CLAUDE_CONFIG_DIR: join(home, ".claude"),
+    CURSOR_CONFIG_DIR: join(home, ".cursor"),
+  };
+  for (const name of REDIRECTED_ENV) {
+    // invariant: every declared destination gets a value here. A name added to the list and not to the map would
+    // otherwise stay pointed at the operator's own path, which is the defect above.
+    env[name] = destinations[name] ?? home;
+  }
+  env.npm_config_prefix = prefix;
+  env.PATH = [prefix, join(prefix, "bin"), base.PATH ?? ""].join(delimiter);
+  return env;
+}
+
+/**
+ * why a prefix and not a real `npm i -g`: a real global install would replace the operator's own command, which is
+ * exactly the class of defect this script exists to catch. The prefix keeps it to a throwaway directory.
  */
 function inPrefix(tarball, version) {
   const prefix = mkdtempSync(join(tmpdir(), "tlc-verify-prefix-"));
@@ -171,13 +204,7 @@ function inPrefix(tarball, version) {
   try {
     const result = runSteps(probeSteps(tarball, version), {
       cwd: process.cwd(),
-      env: {
-        ...process.env,
-        npm_config_prefix: prefix,
-        PATH: [prefix, join(prefix, "bin"), process.env.PATH ?? ""].join(delimiter),
-        HOME: home,
-        USERPROFILE: home,
-      },
+      env: probeEnv(process.env, prefix, home),
     });
     return { ...result, room: `npm prefix ${prefix}, home ${home}` };
   } finally {

--- a/tools/dev/verify-package.mjs
+++ b/tools/dev/verify-package.mjs
@@ -170,21 +170,32 @@ export function runSteps(steps, options) {
  * `bin/` everywhere else. Naming one of them is how a check passes on the platform it was written on and fails on
  * the other.
  */
+/**
+ * The two the suite redirects and this probe must leave absent.
+ *
+ * hazard: pointing them at the throwaway made the launcher look for the runtime *there* — an empty directory,
+ * because `install` has not run yet at that step — and the probe died with "dist/tlc-cli.mjs is missing" on all
+ * three platforms. The suite redirects them because it runs this code in-process against fake paths; an installed
+ * command has to resolve its own runtime out of the package it was installed from, and any value here answers that
+ * question for it ([/decisions/ad-103.md](/decisions/ad-103.md)).
+ */
+const UNSET_HERE = ["TLC_HOME", "TLC_INSTALL_DEST"];
 export function probeEnv(base, prefix, home) {
   const env = { ...base };
-  for (const name of [...PROJECT_SCOPED_ENV, ...RUNTIME_SCOPED_ENV]) {
+  for (const name of [...PROJECT_SCOPED_ENV, ...RUNTIME_SCOPED_ENV, ...UNSET_HERE]) {
     delete env[name];
   }
   const destinations = {
     HOME: home,
     USERPROFILE: home,
-    TLC_HOME: join(home, ".tlc", "harness"),
-    TLC_INSTALL_DEST: join(home, ".tlc", "harness"),
     TLC_BIN_DIR: join(home, ".local", "bin"),
     CLAUDE_CONFIG_DIR: join(home, ".claude"),
     CURSOR_CONFIG_DIR: join(home, ".cursor"),
   };
   for (const name of REDIRECTED_ENV) {
+    if (UNSET_HERE.includes(name)) {
+      continue;
+    }
     // invariant: every declared destination gets a value here. A name added to the list and not to the map would
     // otherwise stay pointed at the operator's own path, which is the defect above.
     env[name] = destinations[name] ?? home;

--- a/tools/dev/verify-package.mjs
+++ b/tools/dev/verify-package.mjs
@@ -156,6 +156,17 @@ export function runSteps(steps, options) {
 }
 
 /**
+ * The two the suite redirects and this probe must leave absent.
+ *
+ * hazard: pointing them at the throwaway made the launcher look for the runtime *there* — an empty directory,
+ * because `install` has not run yet at that step — and the probe died with "dist/tlc-cli.mjs is missing" on all
+ * three platforms. The suite redirects them because it runs this code in-process against fake paths; an installed
+ * command has to resolve its own runtime out of the package it was installed from, and any value here answers that
+ * question for it ([/decisions/ad-103.md](/decisions/ad-103.md)).
+ */
+const UNSET_HERE = ["TLC_HOME", "TLC_INSTALL_DEST"];
+
+/**
  * The child's environment: every name that says *where* pointed at the throwaway, and every name that says *which
  * project* or *which runtime source* removed.
  *
@@ -170,16 +181,6 @@ export function runSteps(steps, options) {
  * `bin/` everywhere else. Naming one of them is how a check passes on the platform it was written on and fails on
  * the other.
  */
-/**
- * The two the suite redirects and this probe must leave absent.
- *
- * hazard: pointing them at the throwaway made the launcher look for the runtime *there* — an empty directory,
- * because `install` has not run yet at that step — and the probe died with "dist/tlc-cli.mjs is missing" on all
- * three platforms. The suite redirects them because it runs this code in-process against fake paths; an installed
- * command has to resolve its own runtime out of the package it was installed from, and any value here answers that
- * question for it ([/decisions/ad-103.md](/decisions/ad-103.md)).
- */
-const UNSET_HERE = ["TLC_HOME", "TLC_INSTALL_DEST"];
 export function probeEnv(base, prefix, home) {
   const env = { ...base };
   for (const name of [...PROJECT_SCOPED_ENV, ...RUNTIME_SCOPED_ENV, ...UNSET_HERE]) {
@@ -225,12 +226,6 @@ function inPrefix(tarball, version) {
 }
 
 /**
- * hazard: this module's main flow ran at module scope, so importing it to test the steps executed `npm pack` and
- * the whole probe. It passed here and failed the macOS leg of CI with a file-level error at line 1 — the module,
- * not a test. This repository already has the rule: no library module self-executes
- * ([/decisions/ad-098.md](/decisions/ad-098.md), [/decisions/ad-102.md](/decisions/ad-102.md)).
- */
-/**
  * `--from <name@version>` drives the *published* version instead of a local tarball.
  *
  * why after the publish as well as before: everything before it reads a tarball this repository produced. What an
@@ -238,6 +233,11 @@ function inPrefix(tarball, version) {
  * entry answered as the CLI. This is the only step that can see that, and it can only see it too late: there is no
  * rollback, so the value is a red run within minutes instead of a person on their own machine days later
  * ([/decisions/ad-103.md](/decisions/ad-103.md)).
+ *
+ * hazard: the separator was found with `lastIndexOf("@")`, which on `@scope/pkg` finds the `@` that starts the
+ * scope — so a scoped name with no version read as version `scope/pkg` and walked straight past the guard written
+ * to stop it. That is this package's own shape. The search starts at index 1 now, where a separator can actually
+ * be ([/decisions/ad-103.md](/decisions/ad-103.md)).
  */
 export function registrySpec(argv) {
   const at = argv.indexOf("--from");
@@ -245,8 +245,9 @@ export function registrySpec(argv) {
   if (spec === null) {
     return null;
   }
-  const version = spec.slice(spec.lastIndexOf("@") + 1);
-  if (version === "" || version === spec) {
+  const separator = spec.indexOf("@", 1);
+  const version = separator < 0 ? "" : spec.slice(separator + 1);
+  if (version === "") {
     fail(`--from needs <name@version>, got ${spec}`);
   }
   return { spec, version };
@@ -259,17 +260,34 @@ export function registrySpec(argv) {
  *
  * invariant: only the install step is retried, and only for as long as the caller allows. Anything after the install
  * succeeded is a real failure and returns immediately.
+ *
+ * hazard: an unreadable value used to become 0 in silence, which makes the flag in the workflow decorative — the
+ * exact failure its own test docstring names. Absent is 0 and present-but-unreadable is fatal, the way `--from`
+ * already behaved ([/decisions/ad-103.md](/decisions/ad-103.md)).
  */
 export function attempts(argv) {
   const at = argv.indexOf("--retries");
-  const parsed = at < 0 ? 0 : Number.parseInt(argv[at + 1] ?? "", 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  if (at < 0) {
+    return 0;
+  }
+  const given = argv[at + 1] ?? "";
+  const parsed = Number.parseInt(given, 10);
+  if (!/^\d+$/.test(given.trim()) || !Number.isFinite(parsed)) {
+    fail(`--retries needs a whole number, got ${JSON.stringify(given)}`);
+  }
+  return parsed;
 }
 
 function sleepSeconds(seconds) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, seconds * 1000);
 }
 
+/**
+ * hazard: this module's main flow ran at module scope, so importing it to test the steps executed `npm pack` and the
+ * whole probe. It passed here and failed the macOS leg of CI with a file-level error at line 1 — the module, not a
+ * test. This repository already has the rule: no library module self-executes
+ * ([/decisions/ad-098.md](/decisions/ad-098.md), [/decisions/ad-102.md](/decisions/ad-102.md)).
+ */
 if (import.meta.main) {
   const published = registrySpec(process.argv);
   if (published !== null) {

--- a/tools/dev/verify-package.mjs
+++ b/tools/dev/verify-package.mjs
@@ -7,11 +7,16 @@
  * their own machine, after publish. The published practice is to pack, install the tarball the way `npx` would, and
  * drive the real binary ([/decisions/ad-102.md](/decisions/ad-102.md)).
  *
- * why a container when one is available: it is the clean room for free — no ambient `node_modules`, no global
- * state, no `PATH` leakage, and no chance of touching the operator's own install. Without docker the same script
- * runs against a throwaway npm prefix, which covers packaging and the command's own behaviour but shares the host's
- * filesystem. The output says which of the two ran, because a weaker check reported as the stronger one is worse
- * than no check.
+ * why one room on every platform instead of a container on one: the container was the stronger clean room and it
+ * only exists on Linux, so the artefact that reaches operators was installed and driven on Linux and nowhere else —
+ * while every defect that reached them was an install defect, and install is the most platform-shaped code in the
+ * package (`~/.local/bin` against a `.cmd` shim, `PATH` against `PATHEXT`, a link against a copy). On a CI runner
+ * the whole machine is already throwaway, so the container's extra isolation bought little; a third platform buys a
+ * class of defect nothing else here can see ([/decisions/ad-103.md](/decisions/ad-103.md)).
+ *
+ * invariant: no shell composition. Each step is its own process with its own exit status, so there is no `&&` chain
+ * for a trailing `||` to swallow and no POSIX-only script for Windows to choke on. A shell is still what resolves
+ * `npm` and `tlc` from `PATH`, which is all `shell: true` per step is for.
  *
  * invariant: this is a release step, not a gate step. It needs the network to resolve dependencies, so it does not
  * belong in the loop a contributor runs on every change.
@@ -19,13 +24,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-
-const NODE_IMAGE = "node:24-alpine";
-
-function run(command, args, options = {}) {
-  return spawnSync(command, args, { encoding: "utf8", ...options });
-}
+import { delimiter, join, resolve } from "node:path";
 
 function fail(message) {
   console.error(`verify-package: ${message}`);
@@ -41,20 +40,18 @@ function packageIdentity() {
 /**
  * invariant: the file list is asserted before anything is installed. A tarball missing `bin/` installs a command
  * that cannot run, and that is cheaper to catch here than after the registry has it for good.
+ *
+ * why npm's own list and not `tar -tzf`: `tar` is not a command on Windows, and what npm prints is what npm packed
+ * rather than a second reading of it.
  */
-export function assertPayload(tarball) {
-  const listed = run("tar", ["-tzf", tarball]);
-  if (listed.status !== 0) {
-    fail(`cannot read ${tarball}: ${listed.stderr}`);
-  }
-  const entries = listed.stdout.split("\n");
+export function assertPayload(entries) {
   const required = [
-    "package/package.json",
-    "package/bin/tlc",
-    "package/bin/tlc.mjs",
-    "package/bin/tlc-exec.mjs",
-    "package/dist/tool-before.mjs",
-    "package/skills/harness-init/SKILL.md",
+    "package.json",
+    "bin/tlc",
+    "bin/tlc.mjs",
+    "bin/tlc-exec.mjs",
+    "dist/tool-before.mjs",
+    "skills/harness-init/SKILL.md",
   ];
   const missing = required.filter((path) => !entries.includes(path));
   if (missing.length > 0) {
@@ -63,127 +60,222 @@ export function assertPayload(tarball) {
   // hazard: `tools/dev` holds the checks that validate *this* repository, and with Bun present the launcher
   // resolves an entry straight from source — so shipping them would put runnable repo-only commands on a user's
   // machine ([/decisions/ad-068.md](/decisions/ad-068.md)).
-  const leaked = entries.filter((path) => path.startsWith("package/tools/dev/") || path.includes("/__test__/"));
+  const leaked = entries.filter((path) => path.startsWith("tools/dev/") || path.includes("/__test__/"));
   if (leaked.length > 0) {
     fail(`the tarball ships what it must not: ${leaked.slice(0, 5).join(", ")}`);
   }
-  const kept = entries.filter(Boolean);
-  console.log(`verify-package: payload ok (${kept.length} entries)`);
+  console.log(`verify-package: payload ok (${entries.length} entries)`);
   /**
    * why the entries are returned and used: an independent review deleted the call to this function and every test
    * stayed green, because the assertions read the script's *source* for the strings it checks. Handing the caller a
    * value it needs makes removing the call a runtime error rather than a convention nobody enforces
    * ([/decisions/ad-102.md](/decisions/ad-102.md)).
    */
-  return kept;
+  return entries;
 }
 
 /**
- * The commands the clean room runs, as data.
+ * The clean room's steps, as data.
  *
- * why a list and not a string: an independent review deleted the `tlc harness doctor` line and the test stayed
- * green, because it asserted the script's source *contained* that text — and the version check on the next line
- * contains it too. A list can be asserted element by element ([/decisions/ad-102.md](/decisions/ad-102.md)).
+ * why a list of records and not one script: an independent review deleted the `tlc harness doctor` line and the
+ * test stayed green, because it asserted the script's source *contained* that text — and the version check on the
+ * next line contained it too. A list can be asserted element by element
+ * ([/decisions/ad-102.md](/decisions/ad-102.md)).
+ *
+ * why `expect` is a field rather than a `grep` step: `grep` is not a command on Windows, and a pipeline's exit
+ * status was the other half of the swallowed-failure defect. The runner reads the captured output instead.
  */
-export function probeCommands(tarball, version) {
+export function probeSteps(tarball, version) {
   return [
-    `npm i -g /work/${tarball} --silent`,
+    { label: "the tarball installs globally, the way npx would", command: `npm i -g "${tarball}" --silent` },
     // why version first: it is the one command that fails loudly when the shim exists but the runtime does not.
-    "tlc harness version",
-    "tlc harness install",
+    { label: "the installed command answers", command: "tlc harness version" },
+    { label: "a fresh install completes", command: "tlc harness install" },
     // why doctor: it is the reading an operator is told to trust, so it has to survive a fresh install with no
-    // project, no config and no prior state.
-    "tlc harness doctor",
-    // why the version is read back out of `doctor`: the tarball says one thing, and the runtime an operator reads
-    // is what matters. A shim resolving an older runtime reports the older version.
-    `tlc harness doctor | grep -q "harness version — ${version}"`,
+    // project, no config and no prior state. The version is read back out of it because the tarball says one thing
+    // and the runtime an operator reads is what matters — a shim resolving an older runtime reports the older one.
+    {
+      label: "doctor survives a fresh install and reports this version",
+      command: "tlc harness doctor",
+      expect: `harness version — ${version}`,
+    },
   ];
 }
 
 /**
- * hazard: these were joined with ` && ` and ended in `|| echo "<message>"`. `&&` and `||` share precedence, so any
- * failure anywhere in the chain fell into the `||` and the compound command exited 0 — which made the status check
- * below unreachable, hid the clean room's stderr entirely, and reported every possible failure as the same wrong
- * message. Proven: `sh -c 'true && false && echo x | grep -q y || echo swallowed'` exits 0
- * ([/decisions/ad-102.md](/decisions/ad-102.md)).
+ * npm's own report of what it packed, out of a stream that is not only that report.
  *
- * invariant: `set -e` and one command per line, so the first failure is the exit status and the reason reaches the
- * operator as itself.
+ * hazard: `prepack` runs the bundler, so `JSON.parse` on the whole stdout dies on the letter `l` of `tlc-build`.
+ * `--silent` does not help: it silences npm, not the script npm runs. Nor does scanning for the first `[`, because
+ * the bundler colours its output and an ANSI escape *starts* with one — which is the second thing this function was
+ * written wrong as.
+ *
+ * why from the end: npm's report is the last document on the stream. Both shapes it has used are handled — an array
+ * of reports, and an object keyed by package name ([/decisions/ad-103.md](/decisions/ad-103.md)).
  */
-export function composeProbe(commands) {
-  return ["set -e", ...commands].join("\n");
-}
-
-function inContainer(tarball, version) {
-  const probe = run("docker", [
-    "run",
-    "--rm",
-    "-v",
-    `${process.cwd()}:/work:ro`,
-    "-w",
-    "/tmp",
-    NODE_IMAGE,
-    "sh",
-    "-c",
-    composeProbe(probeCommands(tarball, version)),
-  ]);
-  return { ...probe, room: `container (${NODE_IMAGE})` };
+export function parsePackReport(stdout) {
+  const lines = stdout.split("\n");
+  for (let start = lines.length - 1; start >= 0; start -= 1) {
+    const opener = (lines[start] ?? "").trim();
+    if (opener !== "[" && opener !== "{") {
+      continue;
+    }
+    try {
+      return Object.values(JSON.parse(lines.slice(start).join("\n")))[0] ?? null;
+    } catch {
+      // why swallowed: a line that merely looks like the start of the report is not one, and the next candidate
+      // further up is the answer. Throwing here would report a parse error about the wrong text.
+    }
+  }
+  return null;
 }
 
 /**
- * why a prefix and not just `npm i -g`: a real global install would replace the operator's own command, which is
+ * Runs the steps in order and stops at the first failure.
+ *
+ * hazard: these used to be joined with ` && ` and ended in `|| echo "<message>"`. `&&` and `||` share precedence,
+ * so any failure anywhere in the chain fell into the `||` and the compound command exited 0 — which made the status
+ * check unreachable, hid the clean room's stderr entirely, and reported every possible failure as the same wrong
+ * message. Proven: `sh -c 'true && false && echo x | grep -q y || echo swallowed'` exits 0. One process per step
+ * removes the composition that made it possible ([/decisions/ad-102.md](/decisions/ad-102.md)).
+ */
+export function runSteps(steps, options) {
+  for (const [index, step] of steps.entries()) {
+    const result = spawnSync(step.command, { ...options, shell: true, encoding: "utf8" });
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    if (result.status !== 0) {
+      return { ok: false, step, index, output, reason: `exit ${result.status ?? "signal"}` };
+    }
+    if (step.expect !== undefined && !output.includes(step.expect)) {
+      return { ok: false, step, index, output, reason: `output does not contain ${JSON.stringify(step.expect)}` };
+    }
+    console.log(`verify-package: ok — ${step.label}`);
+  }
+  return { ok: true };
+}
+
+/**
+ * why a prefix and not a real `npm i -g`: a real global install would replace the operator's own command, which is
  * exactly the class of defect this script exists to catch. The prefix keeps it to a throwaway directory.
+ *
+ * why both `<prefix>` and `<prefix>/bin` are on PATH: npm puts the shim directly in the prefix on Windows and in
+ * `bin/` everywhere else. Naming one of them is how a check passes on the platform it was written on and fails on
+ * the other.
+ *
+ * why HOME and USERPROFILE both: `os.homedir()` reads the first on POSIX and the second on Windows, and the install
+ * writes the runtime, the provider config and the launcher link under it.
  */
 function inPrefix(tarball, version) {
   const prefix = mkdtempSync(join(tmpdir(), "tlc-verify-prefix-"));
+  const home = mkdtempSync(join(tmpdir(), "tlc-verify-home-"));
   try {
-    const probe = run("sh", ["-c", composeProbe(probeCommands(tarball, version))], {
+    const result = runSteps(probeSteps(tarball, version), {
       cwd: process.cwd(),
       env: {
         ...process.env,
         npm_config_prefix: prefix,
-        PATH: `${join(prefix, "bin")}:${process.env.PATH ?? ""}`,
-        HOME: mkdtempSync(join(tmpdir(), "tlc-verify-home-")),
+        PATH: [prefix, join(prefix, "bin"), process.env.PATH ?? ""].join(delimiter),
+        HOME: home,
+        USERPROFILE: home,
       },
     });
-    return { ...probe, room: `npm prefix ${prefix} (no container — weaker: shares the host filesystem)` };
+    return { ...result, room: `npm prefix ${prefix}, home ${home}` };
   } finally {
     rmSync(prefix, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true });
   }
-}
-
-function dockerAvailable() {
-  return run("docker", ["info"], { stdio: "ignore" }).status === 0;
 }
 
 /**
- * hazard: this ran at module scope, so importing the module to test `probeCommands` executed `npm pack` and the
- * whole container probe. It passed here and failed the macOS leg of CI with a file-level error at line 1 — the
- * module, not a test. This repository already has the rule: no library module self-executes
+ * hazard: this module's main flow ran at module scope, so importing it to test the steps executed `npm pack` and
+ * the whole probe. It passed here and failed the macOS leg of CI with a file-level error at line 1 — the module,
+ * not a test. This repository already has the rule: no library module self-executes
  * ([/decisions/ad-098.md](/decisions/ad-098.md), [/decisions/ad-102.md](/decisions/ad-102.md)).
  */
+/**
+ * `--from <name@version>` drives the *published* version instead of a local tarball.
+ *
+ * why after the publish as well as before: everything before it reads a tarball this repository produced. What an
+ * operator installs is what the registry serves, and the two have differed — 0.3.2 shipped bundles where every
+ * entry answered as the CLI. This is the only step that can see that, and it can only see it too late: there is no
+ * rollback, so the value is a red run within minutes instead of a person on their own machine days later
+ * ([/decisions/ad-103.md](/decisions/ad-103.md)).
+ */
+export function registrySpec(argv) {
+  const at = argv.indexOf("--from");
+  const spec = at < 0 ? null : (argv[at + 1] ?? null);
+  if (spec === null) {
+    return null;
+  }
+  const version = spec.slice(spec.lastIndexOf("@") + 1);
+  if (version === "" || version === spec) {
+    fail(`--from needs <name@version>, got ${spec}`);
+  }
+  return { spec, version };
+}
+
+/**
+ * why a bounded retry and not a fixed sleep: a registry is eventually consistent across its CDN, so the version can
+ * be seconds behind the publish that created it. A failure here has to mean the package is broken, not that it is
+ * new — and a sleep long enough to be safe is a sleep every green run pays.
+ *
+ * invariant: only the install step is retried, and only for as long as the caller allows. Anything after the install
+ * succeeded is a real failure and returns immediately.
+ */
+export function attempts(argv) {
+  const at = argv.indexOf("--retries");
+  const parsed = at < 0 ? 0 : Number.parseInt(argv[at + 1] ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function sleepSeconds(seconds) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, seconds * 1000);
+}
+
 if (import.meta.main) {
+  const published = registrySpec(process.argv);
+  if (published !== null) {
+    const retries = attempts(process.argv);
+    let probe = inPrefix(published.spec, published.version);
+    // invariant: only step 0 — resolving and installing the spec — is retried. A runtime that installed and then
+    // failed to answer is broken, and waiting will not change that.
+    for (let attempt = 1; attempt <= retries && !probe.ok && probe.index === 0; attempt += 1) {
+      console.log(`verify-package: ${published.spec} not installable yet — attempt ${attempt} of ${retries}`);
+      sleepSeconds(10);
+      probe = inPrefix(published.spec, published.version);
+    }
+    console.log(`verify-package: clean room = ${probe.room}`);
+    if (!probe.ok) {
+      process.stderr.write(probe.output ?? "");
+      fail(`${probe.step.label} — ${probe.reason}`);
+    }
+    console.log(`verify-package: ok — ${published.spec} installs from the registry and answers on ${process.platform}`);
+    process.exit(0);
+  }
+
   const { version } = packageIdentity();
-  const packed = run("npm", ["pack", "--silent"]);
+  // why `--json`: it writes the tarball and prints what went into it, so the payload assertion reads npm's own
+  // answer instead of shelling out to a second tool Windows does not have.
+  const packed = spawnSync("npm", ["pack", "--json"], { encoding: "utf8", shell: true });
   if (packed.status !== 0) {
     fail(`npm pack failed: ${packed.stderr}`);
   }
-  const tarball = packed.stdout.trim().split("\n").pop() ?? "";
-  if (!existsSync(tarball)) {
-    fail(`npm pack reported ${tarball}, which is not there`);
+  const report = parsePackReport(packed.stdout ?? "");
+  const tarball = resolve(report?.filename ?? "");
+  if (report === null || !existsSync(tarball)) {
+    fail(`npm pack reported ${report?.filename}, which is not there`);
   }
 
   try {
-    const entries = assertPayload(tarball);
-    const probe = dockerAvailable() ? inContainer(tarball, version) : inPrefix(tarball, version);
+    const entries = assertPayload((report.files ?? []).map((file) => file.path));
+    const probe = inPrefix(tarball, version);
     console.log(`verify-package: clean room = ${probe.room}, ${entries.length} entries`);
-    process.stdout.write(probe.stdout ?? "");
-    if ((probe.status ?? 1) !== 0) {
-      // invariant: the clean room's own stderr, which is the only place the real reason exists.
-      process.stderr.write(probe.stderr ?? "");
-      fail(`the installed command failed in the clean room (exit ${probe.status})`);
+    if (!probe.ok) {
+      // invariant: the clean room's own output, which is the only place the real reason exists.
+      process.stderr.write(probe.output ?? "");
+      fail(`${probe.step.label} — ${probe.reason}`);
     }
-    console.log(`verify-package: ok — ${version} installs and answers in a clean room`);
+    console.log(`verify-package: ok — ${version} installs and answers on ${process.platform}`);
   } finally {
     rmSync(tarball, { force: true });
   }


### PR DESCRIPTION
Two holes between "the gate is green" and "an operator's machine still works".

## 1. The artefact was only ever installed on Linux

`verify-package.mjs` packed the tarball, installed it and drove it — on ubuntu, inside a container, because the container only exists there. Every install defect that reached an operator (0.3.0 installed nothing, 0.3.2 shipped bundles where every entry answered as the CLI, 0.4.0 left `tlc` off `PATH`) was an install defect, and install is the most platform-shaped code in the package.

- A matrix job packs, installs and drives it on **ubuntu, macOS and Windows**, and `release` cannot start without it.
- It runs **before the approval**, because the approval is a person deciding to make something irreversible.
- After the publish, a second matrix installs the **published** version from the registry and drives it. It cannot prevent anything — there is no rollback — but it turns "an operator finds it days later" into "the run goes red in minutes".

Making that possible meant removing the shell: one process per step, each with its own exit status, the version asserted against captured output instead of a `grep` pipeline, and the payload read from npm's own `--json` report instead of `tar -tzf`. Both were POSIX-only, which is why this had never run on Windows.

## 2. Nothing checked that an inert scope was telling the truth

`fix(gate)` never releases, by design. Nothing checked that a commit wearing that scope was really plumbing — and one that fixed `tools/doctor.ts`, a file the package ships, earned no version. It travelled only because an unrelated `fix` happened to be sitting on `main` to carry it.

`tools/dev/check-scopes.ts` asks npm which paths it would publish and fails the pull request when an inert scope changes one of them. Documentation is exempt. It reads the scope only on a type that would otherwise release, so `chore(release)` stays inert with no exception written for it.

## Evidence

- `tlc harness test` — all steps passed, twice (plain and with `TLC_HOME="$PWD"`).
- `node tools/dev/verify-package.mjs` — packs, installs, drives; **ok** on linux here.
- `node tools/dev/verify-package.mjs --from @tech-leads-club/harness-toolkit@0.4.3` — the currently published version installs from the registry and answers.
- A missing version exits 1 after its retries rather than hanging.
- `check-scopes` calibrated against the real commit: reports `ae6d1f2` for `tools/doctor.ts` and `src/core/core.facade.ts`, silent on the rest.
- The payload test now runs the check in a child process instead of reading the script's source — the pattern that had already been broken twice by review, and which failed on a correct script the moment the prefix changed.

macOS and Windows have never installed this package before, so those two legs are the point: if either goes red, that is the class of defect this exists to find.

[`docs/decisions/ad-103.md`](docs/decisions/ad-103.md)