### PR TITLE
fix(comments): the rail scanned by a nine-extension regex, not the syntax catalog

### DIFF
--- a/src/core/comment-policy/__test__/comment-policy.test.ts
+++ b/src/core/comment-policy/__test__/comment-policy.test.ts
@@ -7,6 +7,7 @@ import { test } from "node:test";
 import {
   attachedIdentifier,
   commentViolationMessage,
+  filterCommentTargets,
   findAddedComments,
   isCommentLine,
   type NextCodeLine,
@@ -373,4 +374,20 @@ test("an unknown extension is named, not silently passed", async () => {
   assert.deepEqual(unknownExtensions(["a.ts", "b.py", "c.cobol", "d.unknownext"]), [".cobol", ".unknownext"]);
   assert.deepEqual(unknownExtensions(["a.ts", "Dockerfile", "Makefile"]), []);
   assert.deepEqual(findAddedComments([{ file: "x.cobol", line: 1, text: "* narration" }]), []);
+});
+
+// invariant: the rail's scan target is the syntax catalog's coverage, not the nine-extension regex `filterCodeTargets`
+// shares with grind and duplication — a project whose changed files are Terraform, SQL, or any of the catalog's
+// other 30+ languages must still be scanned. A stale copy of that narrower list here would silently regress it.
+test("filterCommentTargets keeps every language the syntax catalog covers, not just the grind nine", () => {
+  const files = ["a.ts", "b.tf", "c.sql", "d.yaml", "e.rb", "f.java", "g.sh", "h.unknownext"];
+  assert.deepEqual(filterCommentTargets(files), [
+    "a.ts",
+    "b.tf",
+    "c.sql",
+    "d.yaml",
+    "e.rb",
+    "f.java",
+    "g.sh",
+  ]);
 });

--- a/src/core/comment-policy/comment-policy.service.ts
+++ b/src/core/comment-policy/comment-policy.service.ts
@@ -53,6 +53,16 @@ export const COMMENT_MARKERS = ["why:", "hazard:", "invariant:"] as const;
  * why: `file` decides everything now, so an empty one resolves to no syntax rather than to a permissive union of
  * every delimiter the harness has heard of. The facade keeps this signature; the scanner always has a real path.
  */
+/**
+ * hazard: the rail's own scan target used to be `filterCodeTargets`, a nine-extension regex shared with grind
+ * and duplication. The syntax catalog already knows 40+ languages — Terraform, SQL, YAML, Ruby, Java among
+ * them — so a project whose changed files never carried one of the nine extensions had `mode: "strict"` in its
+ * config and zero comments ever scanned. This filters by the same source the scanner itself trusts.
+ */
+export function filterCommentTargets(relativePaths: string[]): string[] {
+  return relativePaths.filter((path) => syntaxFor(path) !== null);
+}
+
 export function isCommentLine(text: string, file = ""): boolean {
   const syntax = file === "" ? null : syntaxFor(file);
   if (syntax === null) {

--- a/src/core/core.facade.ts
+++ b/src/core/core.facade.ts
@@ -23,6 +23,7 @@ import { ENABLE_HINT } from "./capability/capability.types.ts";
 import {
   commentViolationMessage,
   declaresReason,
+  filterCommentTargets,
   findAddedComments,
   isCommentLine,
   scanAddedComments,
@@ -448,6 +449,7 @@ export const coreFacade = {
     isCommentLine,
     declaresReason,
     commentViolationMessage,
+    filterCommentTargets,
     unknownExtensions,
     KNOWN_EXTENSION_COUNT,
   },

--- a/src/entrypoints/stop.ts
+++ b/src/entrypoints/stop.ts
@@ -470,6 +470,13 @@ export const stopHandler: Handler = async (event: HarnessEvent, ctx: HandlerCont
   const changedFiles = await listChangedRepoFiles(root, turnBase);
   const codeTargets = filterCodeTargets(changedFiles, policy.codePaths);
   const testTargets = filterTestTargets(changedFiles);
+  // why: the comment rail scopes by the syntax catalog (40+ languages), not by `codeTargets`'s nine-extension
+  // regex shared with grind and duplication — a Terraform- or SQL-heavy project changed no file `codeTargets`
+  // would ever keep, and the rail never ran regardless of `comments.mode`.
+  const commentScope = changedFiles.filter((file) =>
+    coreFacade.policy.isUnderCodePaths(file, policy.codePaths),
+  );
+  const commentTargets = coreFacade.commentPolicy.filterCommentTargets(commentScope);
   // why: read from the snapshot taken before this handler patches anything, so a credit written by the previous
   // stop is still visible when the gate it belongs to runs below.
   const pendingCredit = handoff.pending_lesson_credit;
@@ -619,12 +626,12 @@ export const stopHandler: Handler = async (event: HarnessEvent, ctx: HandlerCont
   // rate cannot — was the rule ever needed — by running the checker while the prose is absent. A measurement that
   // can change what it measures is not a measurement ([/decisions/ad-027.md](/decisions/ad-027.md)).
   if (
-    codeTargets.length > 0 &&
+    commentTargets.length > 0 &&
     coreFacade.observe.shouldObserve(policy.observe, "comments", policy.comments.enabled)
   ) {
     const hits = await coreFacade.commentPolicy.scanAddedComments(
       root,
-      codeTargets,
+      commentTargets,
       policy.comments.mode,
       turnBase,
     );
@@ -641,15 +648,17 @@ export const stopHandler: Handler = async (event: HarnessEvent, ctx: HandlerCont
         rule: "comments",
         // why: a language the catalog does not carry produces no findings, which reads identically to "the
         // property held". Naming the extensions is the difference between a clean reading and a blind spot.
-        unknown_extensions: coreFacade.commentPolicy.unknownExtensions(codeTargets).join(",") || "none",
+        // Scoped to `commentScope`, not `commentTargets` — the target set is already syntax-known by
+        // construction, so it could never report the gap it exists to name.
+        unknown_extensions: coreFacade.commentPolicy.unknownExtensions(commentScope).join(",") || "none",
       },
     });
   }
 
-  if (policy.comments.enabled && policy.comments.onViolation === "followup" && codeTargets.length > 0) {
+  if (policy.comments.enabled && policy.comments.onViolation === "followup" && commentTargets.length > 0) {
     const hits = await coreFacade.commentPolicy.scanAddedComments(
       root,
-      codeTargets,
+      commentTargets,
       policy.comments.mode,
       turnBase,
     );


### PR DESCRIPTION
## Summary

`filterCodeTargets` (shared with grind and duplication) only recognises nine
extensions (`ts/tsx/js/jsx/json/mjs/cjs/py/go/rs`). The comment-syntax catalog
the comment rail is supposed to defer to (`comment-syntax.catalog.ts`) covers
40+ languages, including Terraform (`.tf`), SQL, YAML, Ruby, Java, shell.

A project whose changed files never carry one of the nine extensions has
`comments.mode: "strict"` in its config and **zero comments are ever
scanned** — the rail is wired and green while reading the wrong plane.
Found live: a Terraform/dbt-heavy downstream project reported the comment
gate blocking nothing at all.

## Fix

- `filterCommentTargets` (new, in `comment-policy.service.ts`) scopes the
  rail's own target set by the syntax catalog (`syntaxFor`) instead of the
  narrower grind/duplication regex.
- `stop.ts` computes `commentScope` (files under `codePaths`, any extension)
  and `commentTargets` (that set filtered to known syntax) separately from
  the existing `codeTargets`, which stays as-is for grind/duplication —
  those are a different concern, out of scope here.
- `unknown_extensions` observability now reports over `commentScope` instead
  of the pre-filtered `codeTargets`, so it can actually name a coverage gap
  instead of only ever seeing `.json`.

## Test plan

- [x] `TLC_HOME="$PWD" node bin/tlc.mjs harness test` — full gate green (697
      tests, boundaries, wiring, suppressions, docs bundle, manifest)
- [x] New regression test:
      `filterCommentTargets keeps every language the syntax catalog covers,
      not just the grind nine` — asserts `.tf`/`.sql`/`.yaml`/`.rb`/`.java`/`.sh`
      all pass while a genuinely unknown extension is still dropped. This
      test fails against the pre-fix code.
- [ ] Independent review via `/the-judge` (running now, in a separate
      subagent)